### PR TITLE
feat: Remove Link Bandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 | `-max_priority VAL` | `-mp VAL` | Override the maximum traffic flow priority value specified in the configuration file |
 | `-buffer_size VAL` | `-bs VAL` | Override the buffer size specified in the configuration file |
 | `-processing_delay VAL` | `-pd VAL` | Override the header flit router processing delay specified in the configuration file |
-| `-link_bandwidth VAL` | `-lb VAL` | Override the link bandwidth specified in the configuration file |
 | `-analysis` | `-a` | Enables calculation of maximum basic network latency [[1]](#1) and Shi & Burns worst case network latency [[2]](#2) analyses for the configured simulation case |
 | `-no-console-output` | `-nco` | Disables terminal results output, does not affect logging messages |
 | `-results-csv FILE` | `-csv FILE` | Specifies the *csv* file to write full results to, creates the file if it does not exist |
@@ -33,8 +32,6 @@ max_priority: 4
 buffer_size: 16
 # Header processing delay experienced at each router.
 processing_delay: 6
-# Link bandwidth in flits per cycle, cannot exceed half virtual channel size (prevents back pressure invalidating Shi & Burns analysis).
-link_bandwidth: 8
 ```
 
 ### Topology Configuration File

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -126,7 +126,6 @@ const (
 	overideMaxPriorityFlag = "max_priority"
 	overrideBufferSizeFlag = "buffer_size"
 	processingDelayFlag    = "processing_delay"
-	linkBandwidthFlag      = "link_bandwidth"
 )
 
 func ConfigOverridesArgs(app *cli.App) {
@@ -163,13 +162,6 @@ func ConfigOverridesArgs(app *cli.App) {
 			Category:    category,
 			DefaultText: "no-op when unset",
 		},
-		&cli.IntFlag{
-			Name:        linkBandwidthFlag,
-			Aliases:     []string{"lb"},
-			Usage:       fmt.Sprintf(usageBaseStr, linkBandwidthFlag),
-			Category:    category,
-			DefaultText: "no-op when unset",
-		},
 	)
 }
 
@@ -186,10 +178,6 @@ func ApplyConfigOverrides(ctx *cli.Context, conf domain.SimConfig) domain.SimCon
 	if ctx.IsSet(processingDelayFlag) {
 		conf.ProcessingDelay = ctx.Int(processingDelayFlag)
 	}
-	if ctx.IsSet(linkBandwidthFlag) {
-		conf.LinkBandwidth = ctx.Int(linkBandwidthFlag)
-	}
-
 	return conf
 }
 

--- a/example/basic/config.yaml
+++ b/example/basic/config.yaml
@@ -2,4 +2,3 @@ cycle_limit: 160000
 max_priority: 10
 buffer_size: 20
 processing_delay: 6
-link_bandwidth: 1

--- a/example/high-load/config.yaml
+++ b/example/high-load/config.yaml
@@ -2,4 +2,3 @@ cycle_limit: 160000
 max_priority: 20
 buffer_size: 80
 processing_delay: 6
-link_bandwidth: 2

--- a/example/xiong-et-al/config.yaml
+++ b/example/xiong-et-al/config.yaml
@@ -2,4 +2,3 @@ cycle_limit: 2000000
 max_priority: 5
 buffer_size: 50
 processing_delay: 3
-link_bandwidth: 1

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -18,7 +18,6 @@ var (
 	ErrInvalidMaxPriority     = errors.New("invalid max priority")
 	ErrInvalidBufferSize      = errors.New("invalid buffer size")
 	ErrInvalidProcessingDelay = errors.New("invalid processing delay")
-	ErrInvalidLinkBandwidth   = errors.New("invalid link bandwidth")
 )
 
 func ReadConfig(fPath string) (domain.SimConfig, error) {
@@ -80,18 +79,6 @@ func validate(conf domain.SimConfig) error {
 	if conf.ProcessingDelay < 1 {
 		err := errors.Join(ErrInvalidConfig, ErrInvalidProcessingDelay)
 		log.Log.Error().Err(err).Int("processing_delay", conf.ProcessingDelay).Msg("processing delay must be greater than 0")
-		return err
-	}
-
-	if conf.LinkBandwidth < 1 {
-		err := errors.Join(ErrInvalidConfig, ErrInvalidLinkBandwidth)
-		log.Log.Error().Err(err).Int("link_bandwidth", conf.LinkBandwidth).Msg("link bandwidth must be greater than 0")
-		return err
-	}
-
-	if 2*conf.LinkBandwidth > (conf.BufferSize / conf.MaxPriority) {
-		err := errors.Join(ErrInvalidConfig, ErrInvalidLinkBandwidth)
-		log.Log.Error().Err(err).Int("link_bandwidth", conf.LinkBandwidth).Int("buffer_size", conf.BufferSize).Int("max_priority", conf.MaxPriority).Msg("link bandwidth must be less then or equal to half virtual channel size, to prevent back-pressure violating Shi & Burns analysis")
 		return err
 	}
 

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -41,7 +41,6 @@ func TestReadConfig(t *testing.T) {
 				CycleLimit:      1000,
 				MaxPriority:     6,
 				BufferSize:      24,
-				LinkBandwidth:   2,
 				ProcessingDelay: 6,
 			},
 		},
@@ -89,26 +88,6 @@ func TestReadConfig(t *testing.T) {
 			err:      ErrInvalidProcessingDelay,
 			overrides: map[string]any{
 				"processing_delay": 0,
-			},
-		},
-		{
-			name:     "invalid_link_bandwidth_zero",
-			baseFile: "valid_basic.yaml",
-			enabled:  true,
-			err:      ErrInvalidLinkBandwidth,
-			overrides: map[string]any{
-				"link_bandwidth": 0,
-			},
-		},
-		{
-			name:     "invalid_link_bandwidth_greater_than_half_virtual_channel_size",
-			baseFile: "valid_basic.yaml",
-			enabled:  true,
-			err:      ErrInvalidLinkBandwidth,
-			overrides: map[string]any{
-				"buffer_size":    12,
-				"max_priority":   6,
-				"link_bandwidth": 2,
 			},
 		},
 	}

--- a/src/config/test_resources/valid_basic.yaml
+++ b/src/config/test_resources/valid_basic.yaml
@@ -1,5 +1,4 @@
 cycle_limit: 1000
 max_priority: 6
 buffer_size: 24
-link_bandwidth: 2
 processing_delay: 6

--- a/src/core/analysis/basic/basic.go
+++ b/src/core/analysis/basic/basic.go
@@ -1,18 +1,12 @@
 package basic
 
 import (
-	"math"
-
 	"main/src/core/analysis/util"
 	"main/src/domain"
 )
 
 func BasicLatency(conf domain.SimConfig, tfr util.TrafficFlowAndRoute) int {
 	noFlits := tfr.PacketSize + util.NoAdditionalFlits
-
-	transmission := float64(noFlits) / float64(conf.LinkBandwidth)
-
-	headerProcessing := len(tfr.Route) * conf.ProcessingDelay
-
-	return int(math.Round(transmission)) + headerProcessing
+	processingDelay := len(tfr.Route) * conf.ProcessingDelay
+	return noFlits + processingDelay
 }

--- a/src/core/analysis/basic/basic_test.go
+++ b/src/core/analysis/basic/basic_test.go
@@ -26,7 +26,6 @@ func TestBasicLatency(t *testing.T) {
 		{
 			conf: domain.SimConfig{
 				ProcessingDelay: 6,
-				LinkBandwidth:   1,
 			},
 			top: topology.ThreeHorozontalLine,
 			tf: domain.TrafficFlowConfig{
@@ -39,7 +38,6 @@ func TestBasicLatency(t *testing.T) {
 		{
 			conf: domain.SimConfig{
 				ProcessingDelay: 3,
-				LinkBandwidth:   1,
 			},
 			top: topology.ThreeHorozontalLine,
 			tf: domain.TrafficFlowConfig{
@@ -52,7 +50,6 @@ func TestBasicLatency(t *testing.T) {
 		{
 			conf: domain.SimConfig{
 				ProcessingDelay: 6,
-				LinkBandwidth:   1,
 			},
 			top: topology.ThreeByThreeMesh,
 			tf: domain.TrafficFlowConfig{
@@ -65,7 +62,6 @@ func TestBasicLatency(t *testing.T) {
 		{
 			conf: domain.SimConfig{
 				ProcessingDelay: 6,
-				LinkBandwidth:   1,
 			},
 			top: topology.ThreeByThreeMesh,
 			tf: domain.TrafficFlowConfig{
@@ -78,7 +74,6 @@ func TestBasicLatency(t *testing.T) {
 		{
 			conf: domain.SimConfig{
 				ProcessingDelay: 6,
-				LinkBandwidth:   2,
 			},
 			top: topology.ThreeHorozontalLine,
 			tf: domain.TrafficFlowConfig{
@@ -86,12 +81,11 @@ func TestBasicLatency(t *testing.T) {
 				PacketSize: 4,
 				Route:      "[n0,n1,n2]",
 			},
-			expected: 21,
+			expected: 24,
 		},
 		{
 			conf: domain.SimConfig{
 				ProcessingDelay: 3,
-				LinkBandwidth:   3,
 			},
 			top: topology.ThreeHorozontalLine,
 			tf: domain.TrafficFlowConfig{
@@ -99,7 +93,7 @@ func TestBasicLatency(t *testing.T) {
 				PacketSize: 12,
 				Route:      "[n0,n1,n2]",
 			},
-			expected: 14,
+			expected: 23,
 		},
 	}
 

--- a/src/core/analysis/shiburns/shiburns_test.go
+++ b/src/core/analysis/shiburns/shiburns_test.go
@@ -126,7 +126,6 @@ func TestShiBurns(t *testing.T) {
 				MaxPriority:     5,
 				BufferSize:      25,
 				ProcessingDelay: 6,
-				LinkBandwidth:   1,
 			},
 			tfs: map[string]tfStruct{
 				"t1": {

--- a/src/core/network/components/connection_test.go
+++ b/src/core/network/components/connection_test.go
@@ -15,21 +15,18 @@ func TestNewConnection(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 
 	t.Run("ImplementsInterface", func(t *testing.T) {
-		conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+		conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 		assert.Implements(t, (*Connection)(nil), conn)
 	})
 
 	t.Run("Valid", func(t *testing.T) {
-		conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+		conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 		assert.NotNil(t, conn.flitChan)
-		assert.Equal(t, bandwidth, cap(conn.flitChan))
 		assert.NotNil(t, conn.creditChan)
-		assert.Equal(t, bandwidth, conn.bandwidth)
 	})
 }
 
@@ -37,9 +34,8 @@ func TestConnectionFlitChannel(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 
-	conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 	assert.Equal(t, conn.flitChan, conn.flitChannel())
 }
@@ -48,10 +44,9 @@ func TestConnectionCreditChannel(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 	var priority int = 1
 
-	conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	conn.creditChan[priority] = make(chan int, 1)
@@ -63,9 +58,8 @@ func TestConnectionGetDestRouterID(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 
-	conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	nodeID := domain.NodeID{ID: "n", Pos: domain.NewPosition(0, 0)}
@@ -77,9 +71,8 @@ func TestConnectionGetSrcRouterID(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 
-	conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	nodeID := domain.NodeID{ID: "n", Pos: domain.NewPosition(0, 0)}
@@ -91,9 +84,8 @@ func TestConnectionSetDestRouterID(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 
-	conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	nodeID := domain.NodeID{ID: "n", Pos: domain.NewPosition(0, 0)}
@@ -105,9 +97,8 @@ func TestConnectionSetSrcRouterID(t *testing.T) {
 	t.Parallel()
 
 	var maxPriority int = 1
-	var bandwidth int = 1
 
-	conn, err := NewConnection(maxPriority, bandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	nodeID := domain.NodeID{ID: "n", Pos: domain.NewPosition(0, 0)}

--- a/src/core/network/components/ports.go
+++ b/src/core/network/components/ports.go
@@ -114,7 +114,7 @@ func (o *outputPortImpl) connection() Connection {
 }
 
 func (o *outputPortImpl) allowedToSend(priority int) bool {
-	return o.credits[priority] > 0 && len(o.conn.flitChannel()) < o.conn.flitBandwidth()
+	return o.credits[priority] > 0 && len(o.conn.flitChannel()) < cap(o.conn.flitChannel())
 }
 
 func (o *outputPortImpl) sendFlit(cycle int, flit packet.Flit) error {

--- a/src/core/network/components/router.go
+++ b/src/core/network/components/router.go
@@ -125,7 +125,7 @@ func (r *routerImpl) SetNetworkInterface(netIntfc NetworkInterface) error {
 		return domain.ErrNilParameter
 	}
 
-	inConn, err := NewConnection(r.simConf.MaxPriority, r.simConf.LinkBandwidth, r.logger)
+	inConn, err := NewConnection(r.simConf.MaxPriority, r.logger)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (r *routerImpl) SetNetworkInterface(netIntfc NetworkInterface) error {
 		return err
 	}
 
-	outConn, err := NewConnection(r.simConf.MaxPriority, r.simConf.LinkBandwidth, r.logger)
+	outConn, err := NewConnection(r.simConf.MaxPriority, r.logger)
 	if err != nil {
 		return err
 	}
@@ -169,13 +169,11 @@ func (r *routerImpl) UpdateOutputPortsCredit() error {
 func (r *routerImpl) RouteBufferedFlits(cycle int) error {
 	r.headerFlitsProcessedPerCycle = make(map[string]bool)
 
-	for b := 0; b < r.simConf.LinkBandwidth; b++ {
-		for p := 1; p <= r.simConf.MaxPriority; p++ {
-			for i := 0; i < len(r.inputPorts); i++ {
-				if flit, exists := r.inputPorts[i].peakBuffer(p); exists {
-					if err := r.arbitrateFlit(cycle, i, flit); err != nil {
-						return err
-					}
+	for p := 1; p <= r.simConf.MaxPriority; p++ {
+		for i := 0; i < len(r.inputPorts); i++ {
+			if flit, exists := r.inputPorts[i].peakBuffer(p); exists {
+				if err := r.arbitrateFlit(cycle, i, flit); err != nil {
+					return err
 				}
 			}
 		}

--- a/src/core/network/components/router_node_test.go
+++ b/src/core/network/components/router_node_test.go
@@ -24,7 +24,6 @@ func TestNewRouterNode(t *testing.T) {
 				BufferSize:      16,
 				MaxPriority:     4,
 				ProcessingDelay: 5,
-				LinkBandwidth:   1,
 			},
 		}
 
@@ -45,7 +44,6 @@ func TestNewRouterNode(t *testing.T) {
 				BufferSize:      -1,
 				MaxPriority:     3,
 				ProcessingDelay: 5,
-				LinkBandwidth:   1,
 			},
 		}
 

--- a/src/core/network/components/router_test.go
+++ b/src/core/network/components/router_test.go
@@ -23,7 +23,6 @@ func testRouter(t *testing.T) *routerImpl {
 				BufferSize:      1,
 				MaxPriority:     1,
 				ProcessingDelay: 1,
-				LinkBandwidth:   1,
 			},
 		},
 		zerolog.New(io.Discard).With().Logger(),
@@ -42,7 +41,7 @@ type testRouterPair struct {
 	BtoA *connectionImpl
 }
 
-func newTestRouterPair(t *testing.T, bufferSize, processingDelay, maxPriority, linkBandwidth int) testRouterPair {
+func newTestRouterPair(t *testing.T, bufferSize, processingDelay, maxPriority int) testRouterPair {
 	aPos := domain.NewPosition(0, 0)
 	bPos := domain.NewPosition(1, 0)
 
@@ -56,7 +55,6 @@ func newTestRouterPair(t *testing.T, bufferSize, processingDelay, maxPriority, l
 				BufferSize:      bufferSize,
 				ProcessingDelay: processingDelay,
 				MaxPriority:     maxPriority,
-				LinkBandwidth:   linkBandwidth,
 			},
 		},
 		zerolog.New(io.Discard).With().Logger(),
@@ -79,7 +77,6 @@ func newTestRouterPair(t *testing.T, bufferSize, processingDelay, maxPriority, l
 				BufferSize:      bufferSize,
 				ProcessingDelay: processingDelay,
 				MaxPriority:     maxPriority,
-				LinkBandwidth:   linkBandwidth,
 			},
 		},
 		zerolog.New(io.Discard).With().Logger(),
@@ -92,13 +89,13 @@ func newTestRouterPair(t *testing.T, bufferSize, processingDelay, maxPriority, l
 	err = rB.SetNetworkInterface(niB)
 	require.NoError(t, err)
 
-	AtoB, err := NewConnection(maxPriority, linkBandwidth, zerolog.New(io.Discard))
+	AtoB, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	rA.RegisterOutputPort(AtoB)
 	rB.RegisterInputPort(AtoB)
 
-	BtoA, err := NewConnection(maxPriority, linkBandwidth, zerolog.New(io.Discard))
+	BtoA, err := NewConnection(maxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 
 	rB.RegisterOutputPort(BtoA)
@@ -135,7 +132,6 @@ func TestNewRouter(t *testing.T) {
 				BufferSize:      1,
 				ProcessingDelay: 1,
 				MaxPriority:     1,
-				LinkBandwidth:   1,
 			},
 		}
 
@@ -159,7 +155,6 @@ func TestNewRouter(t *testing.T) {
 					BufferSize:      0,
 					ProcessingDelay: 1,
 					MaxPriority:     1,
-					LinkBandwidth:   1,
 				},
 			},
 			zerolog.New(io.Discard).With().Logger(),
@@ -174,7 +169,6 @@ func TestNewRouter(t *testing.T) {
 					BufferSize:      1,
 					ProcessingDelay: 0,
 					MaxPriority:     1,
-					LinkBandwidth:   1,
 				},
 			},
 			zerolog.New(io.Discard).With().Logger(),
@@ -195,7 +189,6 @@ func TestRouterNodeID(t *testing.T) {
 				BufferSize:      1,
 				ProcessingDelay: 1,
 				MaxPriority:     1,
-				LinkBandwidth:   1,
 			},
 		},
 		zerolog.New(io.Discard).With().Logger(),
@@ -211,7 +204,7 @@ func TestRouterRegisterInputPort(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		router := testRouter(t)
 
-		conn, err := NewConnection(router.simConf.MaxPriority, router.simConf.LinkBandwidth, zerolog.New(io.Discard))
+		conn, err := NewConnection(router.simConf.MaxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 
 		err = router.RegisterInputPort(conn)
@@ -231,7 +224,7 @@ func TestRouterRegisterInputPort(t *testing.T) {
 
 		router.simConf.BufferSize = 0
 
-		conn, err := NewConnection(router.simConf.MaxPriority, router.simConf.LinkBandwidth, zerolog.New(io.Discard))
+		conn, err := NewConnection(router.simConf.MaxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 
 		err = router.RegisterInputPort(conn)
@@ -245,7 +238,7 @@ func TestRouterRegisterOutputPort(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		router := testRouter(t)
 
-		conn, err := NewConnection(router.simConf.MaxPriority, router.simConf.LinkBandwidth, zerolog.New(io.Discard))
+		conn, err := NewConnection(router.simConf.MaxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 
 		err = router.RegisterOutputPort(conn)
@@ -267,7 +260,7 @@ func TestRouterUpdateOutputMap(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		router := testRouter(t)
 
-		conn1, err := NewConnection(router.simConf.MaxPriority, router.simConf.LinkBandwidth, zerolog.New(io.Discard))
+		conn1, err := NewConnection(router.simConf.MaxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 		port1, err := newOutputPort(conn1, 1, zerolog.New(io.Discard))
 		require.NoError(t, err)
@@ -275,7 +268,7 @@ func TestRouterUpdateOutputMap(t *testing.T) {
 		conn1.SetDstRouter(nodeID1)
 		router.outputPorts = append(router.outputPorts, port1)
 
-		conn2, err := NewConnection(router.simConf.MaxPriority, router.simConf.LinkBandwidth, zerolog.New(io.Discard))
+		conn2, err := NewConnection(router.simConf.MaxPriority, zerolog.New(io.Discard))
 		require.NoError(t, err)
 		port2, err := newOutputPort(conn2, 1, zerolog.New(io.Discard))
 		require.NoError(t, err)
@@ -343,7 +336,7 @@ func TestRouterUpdateOutputPortsCredit(t *testing.T) {
 
 	router := testRouter(t)
 
-	conn, err := NewConnection(router.simConf.MaxPriority, router.simConf.LinkBandwidth, zerolog.New(io.Discard))
+	conn, err := NewConnection(router.simConf.MaxPriority, zerolog.New(io.Discard))
 	require.NoError(t, err)
 	router.RegisterOutputPort(conn)
 
@@ -357,7 +350,7 @@ func TestRouterRouteBufferedFlits(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Valid", func(t *testing.T) {
-		testRouterPair := newTestRouterPair(t, 1, 1, 1, 1)
+		testRouterPair := newTestRouterPair(t, 1, 1, 1)
 
 		pkt := packet.NewPacket("t", "AA", 1, 100, domain.Route{testRouterPair.rA.NodeID(), testRouterPair.rB.NodeID()}, 10, zerolog.New(io.Discard))
 
@@ -391,7 +384,7 @@ func TestRouterReadFromInputPorts(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Valid", func(t *testing.T) {
-		testRouterPair := newTestRouterPair(t, 1, 1, 1, 1)
+		testRouterPair := newTestRouterPair(t, 1, 1, 1)
 
 		flit := packet.NewHeaderFlit("t", "AA", 0, 1, 100, domain.Route{testRouterPair.rA.NodeID(), testRouterPair.rB.NodeID()}, zerolog.New(io.Discard))
 		testRouterPair.AtoB.flitChannel() <- flit
@@ -405,7 +398,7 @@ func TestRouterReadFromInputPorts(t *testing.T) {
 	})
 
 	t.Run("ReadIntoBufferError", func(t *testing.T) {
-		testRouterPair := newTestRouterPair(t, 1, 1, 1, 1)
+		testRouterPair := newTestRouterPair(t, 1, 1, 1)
 
 		flit := packet.NewHeaderFlit("t", "AA", 0, 1, 100, domain.Route{testRouterPair.rA.NodeID(), testRouterPair.rB.NodeID()}, zerolog.New(io.Discard))
 		testRouterPair.AtoB.flitChannel() <- flit

--- a/src/core/network/network.go
+++ b/src/core/network/network.go
@@ -141,7 +141,7 @@ func buildNetwork(top *topology.Topology, conf domain.SimConfig, logger zerolog.
 			return nil, domain.ErrInvalidTopology
 		}
 
-		aToB, err := components.NewConnection(conf.MaxPriority, conf.LinkBandwidth, logger)
+		aToB, err := components.NewConnection(conf.MaxPriority, logger)
 		if err != nil {
 			logger.Error().Err(err).Str("id", edge.ID()).Msg("error creating connection")
 			return nil, err
@@ -155,7 +155,7 @@ func buildNetwork(top *topology.Topology, conf domain.SimConfig, logger zerolog.
 			return nil, err
 		}
 
-		bToA, err := components.NewConnection(conf.MaxPriority, conf.LinkBandwidth, logger)
+		bToA, err := components.NewConnection(conf.MaxPriority, logger)
 		if err != nil {
 			logger.Error().Err(err).Str("id", edge.ID()).Msg("error creating connection")
 			return nil, err

--- a/src/core/simulation/sim_test.go
+++ b/src/core/simulation/sim_test.go
@@ -22,42 +22,30 @@ var (
 		MaxPriority:     1,
 		BufferSize:      2,
 		ProcessingDelay: 3,
-		LinkBandwidth:   1,
 	}
 
 	TwoPriorityConfig = domain.SimConfig{
 		MaxPriority:     2,
 		BufferSize:      4,
 		ProcessingDelay: 3,
-		LinkBandwidth:   1,
-	}
-
-	TwoPriorityConfig2LinkBandwidth = domain.SimConfig{
-		MaxPriority:     2,
-		BufferSize:      4,
-		ProcessingDelay: 3,
-		LinkBandwidth:   2,
 	}
 
 	FourPriorityConfig = domain.SimConfig{
 		MaxPriority:     4,
 		BufferSize:      8,
 		ProcessingDelay: 6,
-		LinkBandwidth:   1,
 	}
 
 	TenPriorityConfig = domain.SimConfig{
 		MaxPriority:     10,
 		BufferSize:      20,
 		ProcessingDelay: 6,
-		LinkBandwidth:   1,
 	}
 
 	TwentyPriorityConfig = domain.SimConfig{
 		MaxPriority:     20,
 		BufferSize:      40,
 		ProcessingDelay: 6,
-		LinkBandwidth:   1,
 	}
 )
 
@@ -92,32 +80,6 @@ var templateTestCases = map[string]templateTestCase{
 		cycles:       1000,
 		topologyFunc: topology.ThreeHorozontalLine,
 		networkConf:  TwoPriorityConfig,
-		traffic: []domain.TrafficFlowConfig{
-			{
-				ID:         "t1",
-				Priority:   1,
-				Period:     50,
-				Deadline:   50,
-				Jitter:     0,
-				PacketSize: 2,
-				Route:      "[n0,n1,n2]",
-			},
-			{
-				ID:         "t2",
-				Priority:   2,
-				Period:     math.MaxInt,
-				Deadline:   math.MaxInt,
-				Jitter:     0,
-				PacketSize: 2,
-				Route:      "[n0,n1,n2]",
-			},
-		},
-	},
-	"3hLineTwoPkts2LinkBandwidth": {
-		templateRun:  true,
-		cycles:       1000,
-		topologyFunc: topology.ThreeHorozontalLine,
-		networkConf:  TwoPriorityConfig2LinkBandwidth,
 		traffic: []domain.TrafficFlowConfig{
 			{
 				ID:         "t1",
@@ -537,20 +499,6 @@ func TestRunSimulation(t *testing.T) {
 				{
 					trafficFlowID: "t2",
 					cycle:         16,
-				},
-			},
-		},
-		"3hLineTwoPkts2LinkBandwidth": {
-			run:              true,
-			templateTestCase: templateTestCases["3hLineTwoPkts2LinkBandwidth"],
-			expected: []expectedPkts{
-				{
-					trafficFlowID: "t1",
-					cycle:         11,
-				},
-				{
-					trafficFlowID: "t2",
-					cycle:         12,
 				},
 			},
 		},

--- a/src/domain/sim.go
+++ b/src/domain/sim.go
@@ -4,6 +4,5 @@ type SimConfig struct {
 	CycleLimit      int `yaml:"cycle_limit" json:"cycle_limit"`
 	MaxPriority     int `yaml:"max_priority" json:"max_priority"`
 	BufferSize      int `yaml:"buffer_size" json:"buffer_size"`
-	LinkBandwidth   int `yaml:"link_bandwidth" json:"link_bandwidth"`
 	ProcessingDelay int `yaml:"processing_delay" json:"processing_delay"`
 }

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -54,7 +54,7 @@ tasks:
     deps:
       - build
     cmds:
-      - ./simulator -c example/basic/config.yaml -t example/basic/3-3-square.xml -tr example/basic/traffic.csv -a -debug
+      - ./simulator -c example/basic/config.yaml -t example/basic/3-3-square.xml -tr example/basic/traffic.csv -a -log
 
   demo-2:
     dir: .


### PR DESCRIPTION
From conversations with Leandro Indrusiak, link bandwidth isn't commonly used in NoCs, instead flit sizes are simply expanded, given the recent implementation of flit based buffer & packet size configuration (#27), link bandwidth can be safely removed and assumed to be 1 flit per connection.